### PR TITLE
feat: add Watchtower to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Open-source projects built with or on top of libghostty.
 - [Supacode](https://github.com/supabitapp/supacode) - An open-source native macOS command center for running coding agents in parallel, powered by libghostty.
 - [Trolley](https://github.com/weedonandscott/trolley) - A terminal emulator runtime for distributing cross-platform TUI applications to end users, powered by libghostty.
 - [VVTerm](https://github.com/vivy-company/vvterm) - A Ghostty-powered SSH client for iOS, iPad, and macOS with iCloud sync and voice-to-command.
+- [Watchtower](https://github.com/markhuot/watchtower) - A stacked terminal emulator with an integrated browser pane.
 - [webterm](https://github.com/rcarmo/webterm) - A web terminal server with a dashboard mode and live terminal tiles, using ghostty-web for WebAssembly-based rendering.
 - [Zmx](https://github.com/neurosnap/zmx) - Session persistence for terminal processes, using libghostty-vt for terminal state restore.
 


### PR DESCRIPTION
This pull request adds a new project to the list of open-source projects built with or on top of `libghostty` in the `README.md` file.

Open-source project additions:

* Added `[Watchtower](https://github.com/markhuot/watchtower)` to the list, describing it as a stacked terminal emulator with an integrated browser pane.