### PR TITLE
fix: Quick fix to update the URL for RootShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 
 - [Echo](https://replay.software/echo) - A fast, modern SSH and Mosh client for iOS and iPadOS powered by Ghostty.
 - [Ghostree](https://github.com/sidequery/ghostree) - A fork of Ghostty with native support for git worktree & AI agents.
-- [RootShell](https://github.com/jc00ke/awesome-libghostty/) - The terminal, reimagined for Apple platforms.
+- [RootShell](https://github.com/kitknox/rootshell) - The terminal, reimagined for Apple platforms.
 - [Spectty](https://github.com/ocnc/spectty) - A fast native SSH & Mosh terminal for iOS.
 - [VVTerm](https://github.com/vivy-company/vvterm) - A Ghostty-powered SSH client for iOS, iPad, and macOS with iCloud sync and voice-to-command.
 - [Watchtower](https://github.com/markhuot/watchtower) - A stacked terminal emulator with an integrated browser pane.


### PR DESCRIPTION
The link for RootShell points to the archived awesome-libghostty project that merged with this one; this appears to be the new URL. :)