### PR TITLE
feat: add emacs-libgterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 
 - [Dotty](https://github.com/codymullins/dotty) - Terminal emulator built with `.NET` + libghostty.
 - [Echo](https://replay.software/echo) - A fast, modern SSH and Mosh client for iOS and iPadOS powered by Ghostty.
+- [emacs-libgterm](https://github.com/rwc9u/emacs-libgterm) - Terminal emulator for Emacs using libghostty-vt, with ANSI colors, scrollback, and cursor sync via a Zig dynamic module.
 - [fantastty](https://github.com/blaine/fantastty) - A macOS terminal emulator built on Ghostty's libghostty with session workspaces, notes, and live tab previews
 - [Ghostree](https://github.com/sidequery/ghostree) - A fork of Ghostty with native support for git worktree & AI agents.
 - [RootShell](https://github.com/kitknox/rootshell) - The terminal, reimagined for Apple platforms.


### PR DESCRIPTION
Add [emacs-libgterm](https://github.com/rwc9u/emacs-libgterm) — a terminal emulator for Emacs using libghostty-vt.

Built as a Zig dynamic module that bridges ghostty-vt with Emacs's module API, following the same architecture as emacs-libvterm but with Ghostty's terminal engine. Features ANSI colors, cell-by-cell styled rendering, full key handling, scrollback, cursor visibility sync, and drag-and-drop file support.

First editor integration using libghostty.