### PR TITLE
feat: add termscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 - [taskers](https://github.com/OneNoted/taskers) - An agent-first terminal workspace app with a Rust shell, flexible terminal backend, and Niri-like tiling model.
 - [tuidoscope](https://github.com/shuv1337/tuidoscope) - A terminal multiplexer for TUI apps with tab sidebar, fuzzy command palette, session persistence, and vim-style navigation, built with OpenTUI, SolidJS, and libghostty.
 - [YEN](https://yen.chat) - Terminal-first IDE with native speech-to-text, stylish themes, and custom notifications.
+- [termscope](https://github.com/mwunsch/termscope) - Headless terminal emulator CLI powered by libghostty-vt.
 
 ## System Integrations & Utilities
 


### PR DESCRIPTION
Add [termscope](https://github.com/mwunsch/termscope) to the AI Tools & Agent Orchestration list in the README.

termscope is a headless terminal emulator CLI powered by libghostty-vt inspired by Playwright automation. It ships along with an agent skill.