### PR TITLE
feat: add ADHDev

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 
 ## AI Tools & Agent Orchestration
 
+- [ADHDev](https://github.com/vilmire/adhdev) - Self-hosted control plane for AI coding agents with a libghostty-backed session-host runtime.
 - [agtmux-term](https://github.com/g960059/agtmux-term) - AI-agent-aware terminal emulator with libghostty and a SwiftUI sidebar.
 - [AiyuTerm](https://github.com/aiyu-ai/AiyuTerm) - Native macOS terminal workspace with multi-repo sidebar, persistent split layouts, SSH, tmux, and real-time AI agent status, powered by Ghostty.
 - [Aizen](https://aizen.win) - Bring order to your projects, environments, and day-to-day work. A macOS workspace for parallel development.


### PR DESCRIPTION
## Summary
- Add ADHDev to the AI tools and agent orchestration section
- Link to the open-source self-hosted repository

## Notes
ADHDev uses Ghostty VT bindings in its session-host/terminal-mux runtime.