### PR TITLE
docs: add phantty (xuzhougeng) to Terminal Apps & Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 - [Nekotty2](https://github.com/kengonakajima/Nekotty2) - Nekotty version 2, based on libghostty-vt.
 - [OpenOwl](https://github.com/sanvibyfish/openowl-app) - A macOS native Git GUI and terminal desktop app built with Swift, libghostty, and Metal GPU rendering.
 - [phantty](https://github.com/arya-s/phantty) - Windows renderer for libghostty-vt.
+- [phantty (xuzhougeng)](https://github.com/xuzhougeng/phantty) - A feature-rich phantty fork with an embedded browser panel, file explorer previews, AI agent sessions, and Kitty graphics support.
 - [Quay](https://github.com/babul/quay) - A native macOS connection manager for SSH & SFTP, built on Ghostty's terminal core.
 - [remux](https://github.com/h3nock/remux) - Native iOS tmux client with a mobile-first UI for persistent terminal sessions.
 - [RootShell](https://github.com/kitknox/rootshell) - The terminal, reimagined for Apple platforms.


### PR DESCRIPTION
Adds [phantty (xuzhougeng)](https://github.com/xuzhougeng/phantty) under Terminal Apps & Clients.

It is an actively developed fork of the already-listed [arya-s/phantty](https://github.com/arya-s/phantty), adding an embedded WebView2 browser panel, a file explorer with previews, AI agent sessions, Kitty graphics protocol support, and remote access. Distinct entry name used to avoid collision with the existing one.