### PR TITLE
feat: add agterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 ## AI Tools & Agent Orchestration
 
 - [ADHDev](https://github.com/vilmire/adhdev) - Self-hosted control plane for AI coding agents with a libghostty-backed session-host runtime.
+- [agterm](https://github.com/umputun/agterm) - A native macOS terminal for AI coding agents that groups sessions into named workspaces, with live agent status and a full control API and CLI, built on libghostty.
 - [agtmux-term](https://github.com/g960059/agtmux-term) - AI-agent-aware terminal emulator with libghostty and a SwiftUI sidebar.
 - [AiyuTerm](https://github.com/aiyu-ai/AiyuTerm) - Native macOS terminal workspace with multi-repo sidebar, persistent split layouts, SSH, tmux, and real-time AI agent status, powered by Ghostty.
 - [Aizen](https://aizen.win) - Bring order to your projects, environments, and day-to-day work. A macOS workspace for parallel development.


### PR DESCRIPTION
Adds [agterm](https://github.com/umputun/agterm) under AI Tools & Agent Orchestration: a native macOS terminal for working with AI coding agents across many sessions, with named workspaces, live agent status, and a full control API and CLI, built on libghostty.