### PR TITLE
feat: add Nexion

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 - [moai-studio](https://github.com/modu-ai/moai-studio) - Pure Rust cross-platform agent IDE with GPUI UI, libghostty-vt terminal, SPEC-first development, and integrated MoAI-ADK orchestration.
 - [moss](https://github.com/stickmy/moss) - A macOS terminal workspace for orchestrating AI coding agents with multi-terminal canvas, agent status tracking, and file preview.
 - [Mux0](https://github.com/10xChengTu/Mux0) - A native macOS terminal built on libghostty, with workspaces, tabs, and split panes plus live status for Claude Code, OpenCode, and Codex sessions.
+- [Nexion](https://nexion.one) - A native macOS workspace built on libghostty, with saved terminal layouts, a built-in browser, git, and an iPhone companion.
 - [paulatty](https://github.com/lancy/paulatty) - An AI agent team workspace built on libghostty.
 - [TheCommander](https://thecommander.app/) - A native macOS AI workspace for coding agents with diff review, git workflow, and worktree management.
 - [Factory Floor](https://github.com/alltuner/factoryfloor) - A native macOS workspace for parallel development with git worktrees, Claude Code agents, and embedded dev servers with automatic port detection.


### PR DESCRIPTION
Adds [Nexion](https://nexion.one) to AI Tools & Agent Orchestration. Is a native macOS workspace built on libghostty with a built-in browser and an iPhone companion.