### PR TITLE
feat: add GraphCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of awesome projects, tools, and resources built with or for libgh
 - [codelima](https://github.com/brianrackle/codelima) - Safely run coding agents in fully isolated local VM sandboxes.
 - [con-terminal](https://github.com/nowledge-co/con-terminal) - The native terminal emulator with a built-in AI harness.
 - [Forjara](https://github.com/lludlow/Forjara) - Multi-agent coding workspaces on your tailnet with a libghostty-powered web terminal.
+- [GraphCode](https://github.com/scgopi/GraphCode) - A native macOS app that wires libghostty-backed agent sessions into a graph, with hand-off, message, and spawn edges that fire unattended.
 - [in0](https://github.com/caspianchan31/in0) - A native macOS terminal multiplexer with live AI agent status, built on libghostty + SwiftUI/AppKit.
 - [limpid](https://github.com/nek0der/limpid) - A macOS-native terminal for the AI coding agent era.
 - [moai-studio](https://github.com/modu-ai/moai-studio) - Pure Rust cross-platform agent IDE with GPUI UI, libghostty-vt terminal, SPEC-first development, and integrated MoAI-ADK orchestration.


### PR DESCRIPTION
Adds GraphCode to AI Tools & Agent Orchestration. Native macOS app built on libghostty (via GhosttyKit); each node is a live terminal, each edge a hand-off, message, or spawn.